### PR TITLE
Fix non-triggering callback for lights

### DIFF
--- a/gfxd.c
+++ b/gfxd.c
@@ -443,6 +443,7 @@ int gfxd_arg_callbacks(int arg_num)
 			}
 			break;
 		}
+		case gfxd_Lightsn:
 		case gfxd_Lightptr:
 		{
 			if (config.light_fn != NULL)


### PR DESCRIPTION
The following data is a use case for how lights callbacks don't seem to work (f3dex2, big endian, word size 4) :
```
DB 02 00 00 00 00 00 18 DC 08 06 0A 09 00 00 08 DC 08 09 0A 09 00 00 00
```
I discovered that, for this macro, arg_type is 73 (gfxd_Lightsn) which wasn't handled in the switch in `gfxd_arg_callbacks`. I added it above `gfxd_Lightptr` which fixed the problem for me.