### PR TITLE
F3DEX2 point lighting support

### DIFF
--- a/gbi.h
+++ b/gbi.h
@@ -239,6 +239,9 @@
 # define G_CULL_FRONT		(gI_(0b1) << 9)
 # define G_CULL_BACK		(gI_(0b1) << 10)
 # define G_SHADING_SMOOTH	(gI_(0b1) << 21)
+# if defined(F3DEX2_POS_LIGHTS)
+#  define G_LIGHTING_POSITIONAL	(gI_(0b1) << 22)
+# endif
 #endif
 
 /* othermode lo */
@@ -3457,10 +3460,25 @@ typedef struct
 	char		pad3;
 } Light_t;
 
+#if defined(F3DEX_GBI_2) && defined(F3DEX2_POS_LIGHTS)
+typedef struct
+{
+	uint8_t		col[3];
+	uint8_t		ca;	/* Constant Attenuation, Must be nonzero */
+	uint8_t		colc[3];
+	uint8_t		la;	/* Linear Attenuation */
+	int16_t		pos[3];
+	uint8_t		qa;	/* Quadratic Attenuation */
+} PosLight_t;
+#endif
+
 typedef union
 {
 	_Alignas(8)
 	Light_t		l;
+#if defined(F3DEX_GBI_2) && defined(F3DEX2_POS_LIGHTS)
+	PosLight_t	p;
+#endif
 } Light;
 
 typedef struct

--- a/uc_argfn.c
+++ b/uc_argfn.c
@@ -423,6 +423,15 @@ UCFUNC int argfn_gm(const gfxd_value_t *v)
 			n += gfxd_puts(" | ");
 		n += gfxd_puts("G_SHADING_SMOOTH");
 	}
+#if defined(F3DEX_GBI_2) && defined(F3DEX2_POS_LIGHTS)
+	if (arg & G_LIGHTING_POSITIONAL)
+	{
+		if (n > 0)
+			n += gfxd_puts(" | ");
+		n += gfxd_puts("G_LIGHTING_POSITIONAL");
+		arg &= ~G_LIGHTING_POSITIONAL;
+	}
+#endif
 	if (arg & G_CLIPPING)
 	{
 		if (n > 0)

--- a/uc_f3dex2.c
+++ b/uc_f3dex2.c
@@ -1,4 +1,5 @@
 #define uc_name gfxd_f3dex2
 #define F3DEX_GBI_2
+#define F3DEX2_POS_LIGHTS
 
 #include "uc.c"


### PR DESCRIPTION
Adds the `G_LIGHTING_POSITIONAL` geometry mode bit and the related light structure, allows libgfxd to identify this geometry mode bit and disassemble it. Enabled by default for f3dex2.
