### PR TITLE
Add support for multiple configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,3 +500,35 @@ Insert the type-formatted value into the output. The type should be one of the
 constants in `gfxd.h`. The number of characters written is returned. The
 macro argument with index `n` can be printed with
 `gfxd_print_value(gfxd_arg_type(n), gfxd_arg_value(n))`.
+
+## Multiple configurations
+A single global or thread-local config is used by default, but multiple
+configurations can be used to quickly switch back and forth between
+different settings.
+
+---
+
+##### `struct gfxd_config *gfxd_alloc_config(void)`
+Allocates a new default-initialized config struct. The return value is an
+opaque pointer to a `struct gfxd_config` that is not meant to be dereferenced,
+only used with `gfxd_free_config` and `gfxd_set_config`.
+
+---
+
+##### `void gfxd_free_config(struct gfxd_config *config)`
+Frees a config struct previously allocated with `gfxd_alloc_config`. The
+config struct must be deselected by `gfxd_set_config` first.
+
+---
+
+##### `void gfxd_set_config(struct gfxd_config *config)`
+Selects the config struct to be used when configuring and executing gfxdis.
+Must not be used while gfxd is executing. Setting `config` to `NULL` selects
+the global or thread-local config.
+
+---
+
+##### `struct gfxd_config *gfxd_get_config(void)`
+Returns a pointer to the currently selected config.
+
+---

--- a/gfxd.c
+++ b/gfxd.c
@@ -233,7 +233,14 @@ void gfxd_free_config(struct gfxd_config *cfg)
 
 void gfxd_set_config(struct gfxd_config *cfg)
 {
-	gfxd_config_ptr = cfg;
+	if (cfg != NULL)
+	{
+		gfxd_config_ptr = cfg;
+	}
+	else
+	{
+		gfxd_config_ptr = &gfxd_default_config;
+	}
 }
 
 struct gfxd_config *gfxd_get_config(void) {

--- a/gfxd.c
+++ b/gfxd.c
@@ -217,26 +217,26 @@ const struct gfxd_config gfxd_default_config_init =
 };
 
 static TLOCAL struct gfxd_config gfxd_default_config = gfxd_default_config_init;
-TLOCAL struct gfxd_config* gfxd_config_ptr = &gfxd_default_config;
+TLOCAL struct gfxd_config *gfxd_config_ptr = &gfxd_default_config;
 
-struct gfxd_config* gfxd_alloc_config(void)
+struct gfxd_config *gfxd_alloc_config(void)
 {
-	struct gfxd_config* cfg = malloc(sizeof(struct gfxd_config));
+	struct gfxd_config *cfg = malloc(sizeof(struct gfxd_config));
 	memcpy(cfg, &gfxd_default_config_init, sizeof(sizeof(struct gfxd_config)));
 	return cfg;
 }
 
-void gfxd_free_config(struct gfxd_config* cfg)
+void gfxd_free_config(struct gfxd_config *cfg)
 {
 	free(cfg);
 }
 
-void gfxd_set_config(struct gfxd_config* cfg)
+void gfxd_set_config(struct gfxd_config *cfg)
 {
 	gfxd_config_ptr = cfg;
 }
 
-struct gfxd_config* gfxd_get_config(void) {
+struct gfxd_config *gfxd_get_config(void) {
 	return gfxd_config_ptr;
 }
 

--- a/gfxd.c
+++ b/gfxd.c
@@ -2,6 +2,7 @@
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #ifdef _WIN32
 # include <io.h>
@@ -175,7 +176,7 @@ static uint32_t typed_arg_u(int type, int idx)
 }
 
 
-TLOCAL struct gfxd_config config =
+const struct gfxd_config gfxd_default_config_init =
 {
 	.ucode = NULL,
 	.endian = gfxd_endian_big,
@@ -214,6 +215,30 @@ TLOCAL struct gfxd_config config =
 	.ucdata_fn = NULL,
 	.dram_fn = NULL,
 };
+
+static TLOCAL struct gfxd_config gfxd_default_config = gfxd_default_config_init;
+TLOCAL struct gfxd_config* gfxd_config_ptr = &gfxd_default_config;
+
+struct gfxd_config* gfxd_alloc_config(void)
+{
+	struct gfxd_config* cfg = malloc(sizeof(struct gfxd_config));
+	memcpy(cfg, &gfxd_default_config_init, sizeof(sizeof(struct gfxd_config)));
+	return cfg;
+}
+
+void gfxd_free_config(struct gfxd_config* cfg)
+{
+	free(cfg);
+}
+
+void gfxd_set_config(struct gfxd_config* cfg)
+{
+	gfxd_config_ptr = cfg;
+}
+
+struct gfxd_config* gfxd_get_config(void) {
+	return gfxd_config_ptr;
+}
 
 void gfxd_input_buffer(const void *buf, int size)
 {

--- a/gfxd.h
+++ b/gfxd.h
@@ -380,6 +380,12 @@ const gfxd_value_t *gfxd_value_by_type(int type, int idx);
 int gfxd_arg_valid(int arg_num);
 int gfxd_arg_callbacks(int arg_num);
 
+
+struct gfxd_config* gfxd_alloc_config(void);
+void gfxd_free_config(struct gfxd_config* config);
+void gfxd_set_config(struct gfxd_config* config);
+struct gfxd_config* gfxd_get_config(void);
+
 extern const gfxd_ucode_t gfxd_f3d;
 extern const gfxd_ucode_t gfxd_f3db;
 extern const gfxd_ucode_t gfxd_f3dex;

--- a/gfxd.h
+++ b/gfxd.h
@@ -381,10 +381,10 @@ int gfxd_arg_valid(int arg_num);
 int gfxd_arg_callbacks(int arg_num);
 
 
-struct gfxd_config* gfxd_alloc_config(void);
-void gfxd_free_config(struct gfxd_config* config);
-void gfxd_set_config(struct gfxd_config* config);
-struct gfxd_config* gfxd_get_config(void);
+struct gfxd_config *gfxd_alloc_config(void);
+void gfxd_free_config(struct gfxd_config *config);
+void gfxd_set_config(struct gfxd_config *config);
+struct gfxd_config *gfxd_get_config(void);
 
 extern const gfxd_ucode_t gfxd_f3d;
 extern const gfxd_ucode_t gfxd_f3db;

--- a/gfxd.h
+++ b/gfxd.h
@@ -380,7 +380,6 @@ const gfxd_value_t *gfxd_value_by_type(int type, int idx);
 int gfxd_arg_valid(int arg_num);
 int gfxd_arg_callbacks(int arg_num);
 
-
 struct gfxd_config *gfxd_alloc_config(void);
 void gfxd_free_config(struct gfxd_config *config);
 void gfxd_set_config(struct gfxd_config *config);

--- a/priv.h
+++ b/priv.h
@@ -14,7 +14,9 @@
 
 #define UCFUNC static inline
 
-#define config gfxd_config__
+#define config (*gfxd_config_ptr)
+
+extern TLOCAL struct gfxd_config* gfxd_config_ptr;
 
 typedef int gfxd_argfn_t(const gfxd_value_t *v);
 
@@ -120,7 +122,5 @@ struct gfxd_config
 	gfxd_ucdata_fn_t *	ucdata_fn;
 	gfxd_dram_fn_t *	dram_fn;
 };
-
-extern TLOCAL struct gfxd_config gfxd_config__;
 
 #endif

--- a/priv.h
+++ b/priv.h
@@ -16,7 +16,7 @@
 
 #define config (*gfxd_config_ptr)
 
-extern TLOCAL struct gfxd_config* gfxd_config_ptr;
+extern TLOCAL struct gfxd_config *gfxd_config_ptr;
 
 typedef int gfxd_argfn_t(const gfxd_value_t *v);
 


### PR DESCRIPTION
Expose the following function to be able to switch between multiple configurations:
```c
struct gfxd_config* gfxd_alloc_config(void);
void gfxd_free_config(struct gfxd_config* config);
void gfxd_set_config(struct gfxd_config* config);
struct gfxd_config* gfxd_get_config(void);
```
